### PR TITLE
Adopt SpeechTranscriber for macOS 15 streaming recognition

### DIFF
--- a/Sermon Scrubber/MainViews/ScrubDocumentView+SharedComponents.swift
+++ b/Sermon Scrubber/MainViews/ScrubDocumentView+SharedComponents.swift
@@ -137,9 +137,15 @@ extension ScrubDocumentView {
             }
             .padding()
             
-            Text("Chunk \(transcriptionManager.currentChunk) of \(transcriptionManager.totalChunks)")
-                .font(.caption)
-                .foregroundColor(.secondary)
+            if transcriptionManager.usesModernTranscriber {
+                Text("Progress: \(Int(transcriptionManager.transcriptionProgress * 100))%")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            } else {
+                Text("Chunk \(transcriptionManager.currentChunk) of \(transcriptionManager.totalChunks)")
+                    .font(.caption)
+                    .foregroundColor(.secondary)
+            }
             
             // Add this to display the activity message
             if !transcriptionManager.currentActivityMessage.isEmpty {


### PR DESCRIPTION
## Summary
- adopt the SpeechTranscriber streaming pipeline on macOS 15 and newer while preserving the chunked recognizer fallback
- surface live transcription updates and progress percentages from the modern Speech framework events
- refresh the transcription progress view to show a percentage when using the modern pipeline

## Testing
- not run (macOS project)


------
https://chatgpt.com/codex/tasks/task_e_68cb16b32828832b9cbd4bfbc320c28e